### PR TITLE
Add an option of customize text. Add config version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ pmd {
 }
 
 group = 'com.jackdaw'
-version = '1.0.7-build-1.2'
+version = '2.0.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/jackdaw/essentialinfo/EssentialInfo.java
+++ b/src/main/java/com/jackdaw/essentialinfo/EssentialInfo.java
@@ -2,6 +2,7 @@ package com.jackdaw.essentialinfo;
 
 import com.google.inject.Inject;
 import com.jackdaw.essentialinfo.configuration.SettingManager;
+import com.jackdaw.essentialinfo.module.connectionTips.ConnectionTips;
 import com.jackdaw.essentialinfo.module.message.Message;
 import com.jackdaw.essentialinfo.module.pinglist.PingList;
 import com.jackdaw.essentialinfo.module.tablist.TabList;
@@ -10,7 +11,6 @@ import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
-import com.jackdaw.essentialinfo.module.connectionTips.ConnectionTips;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
@@ -58,7 +58,7 @@ public class EssentialInfo {
 
         if (setting.isMessageEnabled()) {
             this.proxyServer.getEventManager().register(
-                    this, new Message(this.proxyServer, logger, setting.isCommandToBroadcastEnabled()));
+                    this, new Message(this.proxyServer, logger, setting));
             logger.info("Loaded Message.");
         }
 
@@ -68,7 +68,7 @@ public class EssentialInfo {
         }
 
         if (setting.isConnectionTipsEnabled()) {
-            this.proxyServer.getEventManager().register(this, new ConnectionTips(this.proxyServer));
+            this.proxyServer.getEventManager().register(this, new ConnectionTips(this.proxyServer, setting));
             logger.info("Loaded ConnectionTips.");
         }
     }

--- a/src/main/java/com/jackdaw/essentialinfo/configuration/SettingManager.java
+++ b/src/main/java/com/jackdaw/essentialinfo/configuration/SettingManager.java
@@ -22,11 +22,18 @@ public class SettingManager {
     private final File workingDirectory;
     private final File configFile;
 
+    private static final String lastVersion = "v2.0";
+
     private boolean tabListEnabled;
     private boolean messageEnabled;
     private boolean pingListEnabled;
     private boolean connectionTipsEnabled;
-    private boolean isCommandToBroadcast;
+    private boolean commandToBroadcastEnabled;
+    private boolean customTextEnabled;
+    private String connectionText;
+    private String serverChangeText;
+    private String disconnectionText;
+    private String chatText;
 
     /**
      * Instantiates a new Setting manager.
@@ -47,9 +54,14 @@ public class SettingManager {
         Toml toml = new Toml().read(new File(workingDirectory, "config.toml"));
         this.tabListEnabled = toml.getBoolean("tabList.enabled");
         this.messageEnabled = toml.getBoolean("message.enabled");
-        this.isCommandToBroadcast = toml.getBoolean("message.command-to-broadcast");
+        this.commandToBroadcastEnabled = toml.getBoolean("message.command-to-broadcast");
         this.pingListEnabled = toml.getBoolean("pingList.enabled");
         this.connectionTipsEnabled = toml.getBoolean("connectionTips.enabled");
+        this.customTextEnabled = toml.getBoolean("customText.enable");
+        this.connectionText = toml.getString("customText.connectionText");
+        this.serverChangeText = toml.getString("customText.serverChangeText");
+        this.disconnectionText = toml.getString("customText.disconnectionText");
+        this.chatText = toml.getString("customText.chatText");
     }
 
     private void saveDefaultConfig() throws IOException {
@@ -58,15 +70,28 @@ public class SettingManager {
             if (!aBoolean) logger.warn("Could Not make a new config.toml file.");
         }
         if (!configFile.exists()) {
-            InputStream in = SettingManager.class.getResourceAsStream("/config.toml");
-            assert in != null;
+            newConfig();
+        } else {
+            Toml toml = new Toml().read(new File(workingDirectory, "config.toml"));
+            String v;
             try {
-                Files.copy(in, configFile.toPath());
-            } catch (IOException exception) {
-                throw exception;
-            } finally {
-                in.close();
+                v = toml.getString("version.version");
+                if (v.equals(lastVersion)) {
+                    return;
+                }
+            } catch (Exception ignored) {
             }
+            boolean aBoolean = configFile.delete();
+            if (!aBoolean) logger.warn("Could Not delete old config file.");
+            newConfig();
+        }
+    }
+
+    private void newConfig() throws IOException {
+        InputStream in = SettingManager.class.getResourceAsStream("/config.toml");
+        try (in) {
+            assert in != null;
+            Files.copy(in, configFile.toPath());
         }
     }
 
@@ -94,7 +119,7 @@ public class SettingManager {
      * @return the boolean, i.e. enabled returns true; otherwise, false.
      */
     public boolean isCommandToBroadcastEnabled() {
-        return isCommandToBroadcast;
+        return commandToBroadcastEnabled;
     }
 
     /**
@@ -113,6 +138,51 @@ public class SettingManager {
      */
     public boolean isConnectionTipsEnabled() {
         return connectionTipsEnabled;
+    }
+
+    /**
+     * Is custom text enabled.
+     *
+     * @return the boolean, i.e. enabled returns true; otherwise, false.
+     */
+    public boolean isCustomTextEnabled() {
+        return customTextEnabled;
+    }
+
+    /**
+     * Get Connection Text
+     *
+     * @return the String.
+     */
+    public String getConnectionText() {
+        return connectionText;
+    }
+
+    /**
+     * Get Server Change Text
+     *
+     * @return the String.
+     */
+    public String getServerChangeText() {
+        return serverChangeText;
+    }
+
+    /**
+     * Get Disconnection Text
+     *
+     * @return the String.
+     */
+    public String getDisconnectionText() {
+        return disconnectionText;
+    }
+
+    /**
+     * Get Chat Text
+     *
+     * @return the String.
+     */
+    public String getChatText() {
+        return chatText;
     }
 
 }

--- a/src/main/java/com/jackdaw/essentialinfo/module/connectionTips/ConnectionTips.java
+++ b/src/main/java/com/jackdaw/essentialinfo/module/connectionTips/ConnectionTips.java
@@ -1,5 +1,6 @@
 package com.jackdaw.essentialinfo.module.connectionTips;
 
+import com.jackdaw.essentialinfo.configuration.SettingManager;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
@@ -8,14 +9,23 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
+import org.jetbrains.annotations.NotNull;
 
 public class ConnectionTips {
     // class server
     private final ProxyServer proxyServer;
+    private final String connectionText;
+    private final String serverChangeText;
+    private final String disconnectionText;
+    private final boolean isCustomTextEnabled;
 
     // connect the module to the plugin and server
-    public ConnectionTips(ProxyServer proxyServer) {
+    public ConnectionTips(ProxyServer proxyServer, SettingManager setting) {
         this.proxyServer = proxyServer;
+        this.isCustomTextEnabled = setting.isCustomTextEnabled();
+        this.connectionText = setting.getConnectionText();
+        this.serverChangeText = setting.getServerChangeText();
+        this.disconnectionText = setting.getDisconnectionText();
     }
 
     // listener of player login
@@ -31,33 +41,46 @@ public class ConnectionTips {
     }
 
     // note of connect server
-    private void connectNote(ServerConnectedEvent event){
+    private void connectNote(ServerConnectedEvent event) {
         Player player = event.getPlayer();
+        String playerName = player.getUsername();
+        String server = event.getServer().getServerInfo().getName();
         String sendMessage;
-        if (event.getPreviousServer().isPresent()){
-            sendMessage = player.getUsername() + ": ["
-                    + event.getPreviousServer().get().getServerInfo().getName() + "] -> ["
-                    + event.getServer().getServerInfo().getName() + "]";
+        if (event.getPreviousServer().isPresent()) {
+            String previousServer = event.getPreviousServer().get().getServerInfo().getName();
+            if (isCustomTextEnabled) {
+                sendMessage = this.serverChangeText.replace("%player%", playerName).replace("%previousServer%", previousServer).replace("%server%", server);
+            } else {
+                sendMessage = playerName + ": [" + previousServer + "] -> [" + server + "]";
+            }
             TextComponent textComponent = Component.text(sendMessage);
-            for (RegisteredServer s : this.proxyServer.getAllServers()){
+            for (RegisteredServer s : this.proxyServer.getAllServers()) {
                 s.sendMessage(textComponent);
             }
         } else {
-            sendMessage = player.getUsername() + ": Connected to ["
-                    + event.getServer().getServerInfo().getName() + "].";
+            if (isCustomTextEnabled) {
+                sendMessage = this.connectionText.replace("%player%", playerName).replace("%server%", server);
+            } else {
+                sendMessage = playerName + ": Connected to [" + server + "].";
+            }
             TextComponent textComponent = Component.text(sendMessage);
-            for (RegisteredServer s : this.proxyServer.getAllServers()){
+            for (RegisteredServer s : this.proxyServer.getAllServers()) {
                 s.sendMessage(textComponent);
             }
         }
     }
 
     //note of disconnect server
-    private void disconnectNote(DisconnectEvent event){
-        Player player = event.getPlayer();
-        String sendMessage = player.getUsername() + ": Exited the servers.";
+    private void disconnectNote(@NotNull DisconnectEvent event) {
+        String playerName = event.getPlayer().getUsername();
+        String sendMessage;
+        if (isCustomTextEnabled) {
+            sendMessage = this.disconnectionText.replace("%player%", playerName);
+        } else {
+            sendMessage = playerName + ": Exited the servers.";
+        }
         TextComponent textComponent = Component.text(sendMessage);
-        for (RegisteredServer s : this.proxyServer.getAllServers()){
+        for (RegisteredServer s : this.proxyServer.getAllServers()) {
             s.sendMessage(textComponent);
         }
     }

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -1,4 +1,8 @@
 # essential-playerinfo
+# Configuration version. !Please do not change this option!
+[version]
+    version="v2.0"
+
 # Global tablist
 [tabList]
     enabled=true
@@ -16,3 +20,14 @@
 [connectionTips]
     enabled=true
 
+# Custom Message Setting
+[customText]
+    enable=false
+    # e.g. WDRshadow : Connect to [Server1].
+    connectionText = "%player%: Connect to [%server%]."
+    # e.g. WDRshadow : [Server1] -> [Server2]
+    serverChangeText = "%player%: [%previousServer%] -> [%server%]"
+    # e.g. WDRshadow : Exit the servers.
+    disconnectionText = "%player%: Exit the servers."
+    # e.g. [Server1] <WDRshadow>: Hello World!
+    chatText = "[%server%] <%player%>: "


### PR DESCRIPTION
1. Add an option of customize text for Connection Tips and global chat.
2. Add config version. If you upgrade you plugin from old config version, it will automaticly reset the config to fit the new version plugin.
You can change the custom text in the config file. It could only change to net text. And you can use %player% %server% and %previousServer% to replace the variable.